### PR TITLE
Set GOPATH to zopen working dir

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -48,7 +48,8 @@ cat <<zz
     export PATH="\$(dirname "\${GO_PATH}"):\${PATH}"
 
     # Set the GOPATH to the zopen working dir so as not to fill up $HOME/go
-    export GOPATH="$PWD/go"
+    export GOPATH="\$ZOPEN_ROOT/go"
+    mkdir -p \$GOPATH
   fi
 zz
 }

--- a/buildenv
+++ b/buildenv
@@ -46,6 +46,9 @@ cat <<zz
   if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
     # Set the PATH environment variable to the directory of the Go path
     export PATH="\$(dirname "\${GO_PATH}"):\${PATH}"
+
+    # Set the GOPATH to the zopen working dir so as not to fill up $HOME/go
+    export GOPATH="$PWD/go"
   fi
 zz
 }


### PR DESCRIPTION
Set GOPATH to zopen working dir. This is to avoid filling up the limited space on $HOME/go in Jenkins and to avoid potentially including dependencies from previous runs.